### PR TITLE
Update ELTJobExecutor.ps1

### DIFF
--- a/ELTJobExecutor.ps1
+++ b/ELTJobExecutor.ps1
@@ -4,10 +4,10 @@ Param(
     ,[string]$SourceFile = '.\20230123-115724-8304473-requests-1.csv'
     ,[string]$SqlDataType = 'VARCHAR(MAX)'
     ,[string]$TableName = 'tblNLNGITRequests'
+    ,[string]$PrimaryKey = 'ID'
 )
 
 # ==========================
-Set-Variable -Name 'PrimaryKey' -Value 'ID'
 # Set-Location -Path 'D:\NLNG\Work\webapis\4Me_Batch_Program\ELT_development'
 
 try {


### PR DESCRIPTION
Reassigned the $PrimaryKey variable to the `Param` block and set the default to `ID`. The primary key, `ID` is the first column in the source data used in code development. Please refer to line 52 in [fxStageData.ps1](https://github.com/richardogoma/ELT_Development/blob/main/fxStageData.ps1) project code file.

line 52: ``$sql += ("CREATE TABLE [$TableName]($($CleanHeader[0]) {0} `n" -f 'INT PRIMARY KEY')``
