### PR TITLE
Resolved BCP error

### DIFF
--- a/DML-IntegrationTbl.sql
+++ b/DML-IntegrationTbl.sql
@@ -1,3 +1,13 @@
+-- ================Staging data transformation
+-- There is no field with primary key constraint in the loading table, this is a representation of the integration table design
+DELETE FROM [dbo].[temp_$(TableName)]
+WHERE $(PrimaryKey) LIKE '%[^0-9]%';
+
+ALTER TABLE temp_$(TableName) ALTER COLUMN $(PrimaryKey) INT;
+
+CREATE CLUSTERED INDEX $(PrimaryKey)_ASC ON temp_$(TableName) ($(PrimaryKey));
+GO
+
 -- ================Integration phase
 SELECT COUNT(1) [NewRowsCount] FROM [dbo].[temp_$(TableName)] t
 WHERE NOT EXISTS (


### PR DESCRIPTION
The data had some wild inconsistencies, so resolved by loading all unprocessed data into a staging table with `VARCHAR(MAX)` datatype; the staging table `CREATE TABLE` statement was modified and recreated w/out a PRIMARY KEY constraint.

Executing the `bcp` command on the modified staging table, and we don't experience the errors. 

<img width="671" alt="image" src="https://user-images.githubusercontent.com/108296666/214307905-874f64e7-1f32-4967-bfb7-f6e6c12f844e.png">

The transformation would be done at the staging area before migrating data into the integration table. 

The staging table is defined as `VARCHAR(MAX)` for all fields, while the integration table has a PRIMARY KEY constraint on the ID field. 

To migrate the data, we have to filter out anything on the ID column that has anything that is not in the range of 0-9 characters. [I found this article useful.](https://www.sqlservercentral.com/forums/topic/filter-out-values-are-not-integer-or-null)

```sql
SELECT * FROM [dbo].[temp_tblNLNGITWorkflows]
where ID not like '%[^0-9]%';

DELETE FROM [dbo].[temp_tblNLNGITWorkflows]
where ID like '%[^0-9]%';

ALTER TABLE temp_tblNLNGITWorkflows ALTER COLUMN ID INT;

CREATE CLUSTERED INDEX ID_ASC ON temp_tblNLNGITWorkflows (ID);

SELECT *
FROM sys.indexes
WHERE object_id = OBJECT_ID('temp_tblNLNGITWorkflows');
```

A clustered index was created on the ID column to improve query performance for downstream processing. 
This is predicated on the fact that, we would like to migrate only new data from the staging area into the integration table using a `WHERE NOT EXISTS` statement.