### PR TITLE
Resolved parallel logging error

### DIFF
--- a/fxIntegrateStagedData.ps1
+++ b/fxIntegrateStagedData.ps1
@@ -36,9 +36,10 @@ function IntegrateData {
             $rowcount = Invoke-Sqlcmd @Params
         }
         $output = New-Object PSObject -Property @{'Instance'=$InstanceName;'Database'=$Database;'Table'="[dbo].[$TableName]";'NewRowsCount'=$rowcount.NewRowsCount;'Timestamp'=Get-Date}
-        
-        Write-Output "Loading new data into the integration table" >> ProgramLog.log
-        return $output >> ProgramLog.log
+
+        # Write to log file
+        . .\fxWriteLog.ps1
+        Write-Function -data $output -description "Loading new data into the integration table" -file "ProgramLog.log"
     }
     catch {
         throw $Error[0]; $Error.Clear()

--- a/fxStageData.ps1
+++ b/fxStageData.ps1
@@ -99,9 +99,9 @@ function Import-CsvToSqlTable {
             }
             $output = New-Object PSObject -Property @{'Instance'=$InstanceName;'Database'=$Database;'Table'="$StagingTableName";'RowCount'=$rowcount.RowCount;'Timestamp'=Get-Date}
 
-            Write-Output "Loading source data into the staging area" >> ProgramLog.log
-            return $output >> ProgramLog.log
-            
+            # Write to log file
+            . .\fxWriteLog.ps1
+            Write-Function -data $output -description "Loading source data into the staging area" -file "ProgramLog.log"
         }
         catch{
             throw $Error[0]; $Error.Clear()

--- a/fxWriteLog.ps1
+++ b/fxWriteLog.ps1
@@ -1,0 +1,27 @@
+Function Write-Function {
+    param ($data, $description, $file)
+
+    $retryCount = 0
+    $maxRetries = 10
+
+    while ($retryCount -lt $maxRetries) {
+      try {
+        Write-Output $description | Out-File -FilePath $file -Append
+        $data | Out-File -FilePath $file -Append
+        break
+      } catch [System.IO.IOException] {
+        if ($_.Exception.Message -like "being used by another process") {
+          $retryCount++
+          Write-Host "File is locked, retrying in 1 second..."
+          Start-Sleep -Seconds 1
+        } else {
+          Write-Host "Unexpected error: $_"
+          break
+        }
+      }
+    }
+
+    if ($retryCount -eq $maxRetries) {
+      Write-Host "Maximum number of retries reached, giving up."
+    }
+}


### PR DESCRIPTION
In PowerShell, you can use a **_retry logic_** to handle the scenario where a file is being used by another process. Also, because of the multiplicity of instances where we need the retry logic, we can save the retry logic as a script file and call the script file as a function by **_dot-sourcing the script file_** and then invoking the function with the desired parameters. 